### PR TITLE
Add Cross Compiling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,14 @@ version := "0.8.0-16"
 
 // I'm not sure how this can be automated for multiple versions like it
 // used to be. Knockoff should be buildable from version 2.7.5
-scalaVersion := "2.9.1"
+scalaVersion := "2.9.2"
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "1.6.1" % "test"
+crossScalaVersions := Seq(
+  "2.9.2", "2.9.1-1", "2.9.1",
+  "2.9.0-1", "2.9.0", "2.8.2", "2.8.1"
 )
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "1.7.2" % "test"
 
 publishTo := Some("scala-tools.org releases" at 
                   "http://nexus.scala-tools.org/content/repositories/releases/")


### PR DESCRIPTION
Hey,

I added cross compiling to the build script and the latest version of Scala. I wouldn't worry about versions of Scala in the 2.7.x series.

I'm not sure why, but 2.8.2 failed the integration tests. It looked like it escaped tags it shouldn't have. I thought you would have a better idea as to exactly why ti would fail.
