### PR TITLE
 Remove an unnecessary trailing line break before end tag.

### DIFF
--- a/src/test/scala/com/tristanhunt/knockoff/ChunkParsersSpec.scala
+++ b/src/test/scala/com/tristanhunt/knockoff/ChunkParsersSpec.scala
@@ -12,31 +12,31 @@ class ChunkParsersSpec extends ChunkParser with FunSpecLike with ShouldMatchers 
   describe("ChunkParser") {
     it("should handle simple bullet items") {
       val src = "* item 1\n* item 2\n"
-      parse( chunk, src ).get should equal ( BulletLineChunk("item 1\n") )
+      parse( chunk, src ).get should equal ( BulletLineChunk("item 1") )
     }
-    
+
     it("should group a second line that's not a bullet") {
       val src = "*   item 1\n    more\n"
       parse( chunk, src ).get should equal (
-        BulletLineChunk("item 1\nmore\n")
+        BulletLineChunk("item 1\nmore")
       )
     }
-    
+
     it("should ignore whitespace around headers") {
       val src = "# Header 1 #"
       parse( chunk, src ).get should equal { HeaderChunk(1, "Header 1") }
     }
-    
+
     it("should be ok with empty code blocks") {
       val src = "    "
       parse( chunk, src ).get should equal { IndentedChunk("") }
     }
-    
+
     it("should not explode on a code block with a trailing line") {
       val line = "    line\n    "
-      parse( chunk, line ).get should equal { IndentedChunk("line\n") }
+      parse( chunk, line ).get should equal { IndentedChunk("line") }
     }
-    
+
     it("should handle nothin' but code") {
       val src = "    This is just a code block.\n" +
                 "    \n" +
@@ -45,15 +45,15 @@ class ChunkParsersSpec extends ChunkParser with FunSpecLike with ShouldMatchers 
       parse( chunk, src ).get should equal { IndentedChunk(
         "This is just a code block.\n" +
         "\n" +
-        "And it has a trailing whitespace line... that's also indented.\n"
+        "And it has a trailing whitespace line... that's also indented."
       ) }
     }
-    
+
     it("should deal with a CRLF") {
       val src = "This is a line \r\nthat is broken in\r\n a couple places.\r\n"
-      parse( chunk, src ).get should equal { TextChunk(src) }
+      parse( chunk, src ).get should equal { TextChunk(src.stripSuffix("\r\n")) }
     }
-    
+
     it("should deal with just a CRLF") {
       val src = "\u000d\u000a"
       parse( chunk, src ).get should equal { EmptySpace(src) }


### PR DESCRIPTION
refs: https://github.com/tristanjuricek/knockoff/issues/44

When parsing markdown text as follows, it contains an unexpected trailing line break in the output. I add a procedure that removes this unnecessary line break from the parsing result.

source markdown text:

```
* item1
* item2

1. item1
2. item2

foo bar
baz
```

output:

```
<ul><li>item1
</li><li>item2
</li></ul><ol><li>item1
</li><li>item2
</li></ol><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit,
sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
</p>
```

output (apply this patch)

```
<ul><li>item1</li><li>item2</li></ul><ol><li>item1</li><li>item2</li></ol><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit,
sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
```
