### PR TITLE
Add missing plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")


### PR DESCRIPTION
I am getting exceptions while building knochoff with sbt.

```
/home/docker/workspace/knockoff/build.sbt:29: error: not found: value useGpg
useGpg := true
^
[error] Type error in expression
```

probably, sbt-pgp plugin was missing.
