### PR TITLE
Upgrade to scala 2.12, keep cross-build for 2.10, 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,31 +2,34 @@ name:="knockoff"
 
 version:="0.8.3"
 
-scalaVersion:="2.10.4"
+scalaVersion:="2.12.1"
 
-crossScalaVersions := Seq("2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.4", "2.11.4", "2.12.1")
 
 organization := "com.tristanhunt"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.2" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "junit" % "junit" % "4.11" % "test",
   "net.sf.jtidy" % "jtidy" % "r938" % "test"
 )
 
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+    case Some((2, scalaMajor)) if scalaMajor == 11 =>
       libraryDependencies.value ++ Seq(
         "org.scala-lang.modules" %% "scala-xml" % "1.0.1",
         "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
+      )
+    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+      libraryDependencies.value ++ Seq(
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
       )
     case _ =>
       libraryDependencies.value 
   }
 }
-
-useGpg := true
 
 publishMavenStyle := true
 

--- a/src/test/scala/com/tristanhunt/knockoff/ChunkParsersSpec.scala
+++ b/src/test/scala/com/tristanhunt/knockoff/ChunkParsersSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers._
 import org.scalatest._
 
 @RunWith(classOf[JUnitRunner])
-class ChunkParsersSpec extends ChunkParser with FunSpecLike with ShouldMatchers {
+class ChunkParsersSpec extends ChunkParser with FunSpecLike with Matchers {
 
   describe("ChunkParser") {
     it("should handle simple bullet items") {

--- a/src/test/scala/com/tristanhunt/knockoff/KnockoffIntegrationTests.scala
+++ b/src/test/scala/com/tristanhunt/knockoff/KnockoffIntegrationTests.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable.ListBuffer
 import scala.xml.{ Node, XML }
 
 @RunWith(classOf[JUnitRunner])
-class KnockoffIntegrationTests extends FunSpecLike with ShouldMatchers {
+class KnockoffIntegrationTests extends FunSpecLike with Matchers {
 
 
   val basedir = "src/test/resources/tests"

--- a/src/test/scala/com/tristanhunt/knockoff/SpanConverterSpec.scala
+++ b/src/test/scala/com/tristanhunt/knockoff/SpanConverterSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers._
 import scala.util.parsing.input.NoPosition
 
 @RunWith(classOf[JUnitRunner])
-class SpanConverterSpec extends FunSpecLike with ShouldMatchers {
+class SpanConverterSpec extends FunSpecLike with Matchers {
 
   def convert( txt : String ) : List[Span] = convert( txt, Nil )
 

--- a/src/test/scala/com/tristanhunt/knockoff/StringExtrasSpec.scala
+++ b/src/test/scala/com/tristanhunt/knockoff/StringExtrasSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest._
 import org.scalatest.matchers._
 
 @RunWith(classOf[JUnitRunner])
-class StringExtrasSpec extends FunSpecLike with ShouldMatchers with StringExtras {
+class StringExtrasSpec extends FunSpecLike with Matchers with StringExtras {
     
   describe("StringExtras") {
     it( "should find two different groups of the same time" ) {


### PR DESCRIPTION
Tested building and running tests locally with all three supported scala versions.